### PR TITLE
!Str prefix for interactive keys to pass a string

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -455,6 +455,7 @@ impl<'de> Deserialize<'de> for Command {
 #[derive(Debug, Clone, PartialEq)]
 enum Key {
     Char(char),
+    String(String),
     Control(ControlCode),
     Wait(Duration),
 }

--- a/src/config/run.rs
+++ b/src/config/run.rs
@@ -327,6 +327,11 @@ impl Key {
     fn send(&self, shell_session: &mut ShellSession) -> io::Result<()> {
         match self {
             Self::Char(char) => shell_session.send([*char as u8]),
+
+            Self::String(str) => str
+                .chars()
+                .map(|char| shell_session.send([char as u8]))
+                .collect::<io::Result<()>>(),
             Self::Control(control) => shell_session.send(control),
             Self::Wait(_) => Ok(()),
         }


### PR DESCRIPTION
This is a proposal for implementing a `!Str`  prefix for keys.
Currently, the default delay is not taken into account, but this would work:
```
- !Interactive
  keys:
    - !Str hello
    - 2s
    - ^X
    - n
 ```