### PR TITLE
Add Dependabot configuration for Cargo updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# https://docs.github.com/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This enables dependabot and let's it/GitHub check for outdated dependencies automatically. See [their documentation for more information](https://docs.github.com/code-security/dependabot).

I noticed this project did not receive some updates since some time, so maybe this is a good idea to (semi-)automatically keep it alive? 